### PR TITLE
[Change] add '-dsaparam' to openssl generation of DH parameters file;…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
     - entropy-service
 
 - name: The Diffie-Hellman parameter file is generated
-  command: "{{dhparam_openssl_binary}} dhparam -out '{{ dhparam_file }}' {{ dhparam_size }}"
+  command: "{{dhparam_openssl_binary}} dhparam -dsaparam -out '{{ dhparam_file }}' {{ dhparam_size }}"
   args:
     creates: "{{ dhparam_file }}"
 


### PR DESCRIPTION
… reduces

         run time significantly at no material loss of security
ref: https://security.stackexchange.com/questions/54359/what-is-the-difference-between-diffie-hellman-generator-2-and-5
ref2: https://security.stackexchange.com/questions/95178/diffie-hellman-parameters-still-calculating-after-24-hours